### PR TITLE
Configurable validation

### DIFF
--- a/src/Neverbounce/NeverBounce.php
+++ b/src/Neverbounce/NeverBounce.php
@@ -23,7 +23,7 @@ class NeverBounce
     public function valid($email)
     {
         try {
-            $valid = $this->app->verify($email)->is(NB_Single::GOOD);
+            $valid = $this->app->verify($email)->is(config('neverbounce.valid_results', 'valid'));
         } catch (NB_Exception $e) {
             Log::error($e->getMessage(), ['exception' => $e]);
             $valid = false;

--- a/src/resources/config/neverbounce.php
+++ b/src/resources/config/neverbounce.php
@@ -4,6 +4,9 @@ return [
 
     'secret_key' => env('NEVERBOUNCE_SECRET_KEY'),
     'key' => env('NEVERBOUNCE_USERNAME'),
+    'valid_results' => [
+        'valid'
+    ],
     'router' => env('NEVERBOUNCE_ROUTER', null),
     'version' => env('NEVERBOUNCE_VERSION', null),
 

--- a/src/resources/config/neverbounce.php
+++ b/src/resources/config/neverbounce.php
@@ -2,11 +2,48 @@
 
 return [
 
+	/*
+	|--------------------------------------------------------------------------
+	| Neverbounce Credentials
+	|--------------------------------------------------------------------------
+	|
+	| These are your Neverbounce credentials, found at:
+	| https://app.neverbounce.com/settings/api
+	|
+	*/
+
     'secret_key' => env('NEVERBOUNCE_SECRET_KEY'),
     'key' => env('NEVERBOUNCE_USERNAME'),
+
+    /*
+	|--------------------------------------------------------------------------
+	| Validation Rules
+	|--------------------------------------------------------------------------
+	|
+	| By default, only addresses that return as "valid" will be considered
+	| valid when calling NeverBounce::valid() or using the NeverBounce
+	| form validator. You may want to tweak these settings (for example, you
+	| may want to allow disposable or catchall addresses).
+	|
+	| See: https://neverbounce.com/help/getting-started/result-codes/
+	|
+	*/
+
     'valid_results' => [
         'valid'
     ],
+
+    /*
+	|--------------------------------------------------------------------------
+	| Optional Settings
+	|--------------------------------------------------------------------------
+	|
+	| If you leave these NULL, the default API router and version will be used,
+	| which is most likely what you want. Only set these if you have a good
+	| reason to.
+	|
+	*/
+
     'router' => env('NEVERBOUNCE_ROUTER', null),
     'version' => env('NEVERBOUNCE_VERSION', null),
 

--- a/src/resources/config/neverbounce.php
+++ b/src/resources/config/neverbounce.php
@@ -2,47 +2,47 @@
 
 return [
 
-	/*
-	|--------------------------------------------------------------------------
-	| Neverbounce Credentials
-	|--------------------------------------------------------------------------
-	|
-	| These are your Neverbounce credentials, found at:
-	| https://app.neverbounce.com/settings/api
-	|
-	*/
+    /*
+    |--------------------------------------------------------------------------
+    | Neverbounce Credentials
+    |--------------------------------------------------------------------------
+    |
+    | These are your Neverbounce credentials, found at:
+    | https://app.neverbounce.com/settings/api
+    |
+    */
 
     'secret_key' => env('NEVERBOUNCE_SECRET_KEY'),
     'key' => env('NEVERBOUNCE_USERNAME'),
 
     /*
-	|--------------------------------------------------------------------------
-	| Validation Rules
-	|--------------------------------------------------------------------------
-	|
-	| By default, only addresses that return as "valid" will be considered
-	| valid when calling NeverBounce::valid() or using the NeverBounce
-	| form validator. You may want to tweak these settings (for example, you
-	| may want to allow disposable or catchall addresses).
-	|
-	| See: https://neverbounce.com/help/getting-started/result-codes/
-	|
-	*/
+    |--------------------------------------------------------------------------
+    | Validation Rules
+    |--------------------------------------------------------------------------
+    |
+    | By default, only addresses that return as "valid" will be considered
+    | valid when calling NeverBounce::valid() or using the NeverBounce
+    | form validator. You may want to tweak these settings (for example, you
+    | may want to allow disposable or catchall addresses).
+    |
+    | See: https://neverbounce.com/help/getting-started/result-codes/
+    |
+    */
 
     'valid_results' => [
         'valid'
     ],
 
     /*
-	|--------------------------------------------------------------------------
-	| Optional Settings
-	|--------------------------------------------------------------------------
-	|
-	| If you leave these NULL, the default API router and version will be used,
-	| which is most likely what you want. Only set these if you have a good
-	| reason to.
-	|
-	*/
+    |--------------------------------------------------------------------------
+    | Optional Settings
+    |--------------------------------------------------------------------------
+    |
+    | If you leave these NULL, the default API router and version will be used,
+    | which is most likely what you want. Only set these if you have a good
+    | reason to.
+    |
+    */
 
     'router' => env('NEVERBOUNCE_ROUTER', null),
     'version' => env('NEVERBOUNCE_VERSION', null),


### PR DESCRIPTION
These changes let you set what result types are considered valid. In my case, I would like to allow catchall addresses. Some people may want to allow disposable email addresses.